### PR TITLE
Support building on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-MAKEFLAGS += -j$(shell nproc)
-
 BASENAME  = snowboardkids2
 
 ifndef QUIET
   PRINTF = @printf
 else
   PRINTF = @true
+endif
+
+VERBOSE ?= 0
+ifeq ($(VERBOSE),0)
+  V := @
 endif
 
 # Colours
@@ -40,7 +43,31 @@ O_FILES := $(shell grep -E 'build\/(asm|assets|src|src\/entrypoint|bin|lib\/libk
 
 # Tools
 
-CROSS = mips-linux-gnu-
+find-command = $(shell which $(1) 2>/dev/null)
+
+# try to auto-detect MIPS cross toolchain
+ifneq      ($(call find-command,mips-linux-gnu-ld),)
+  CROSS := mips-linux-gnu-
+else ifneq ($(call find-command,mips64-linux-gnu-ld),)
+  CROSS := mips64-linux-gnu-
+else ifneq ($(call find-command,mips64-elf-ld),)
+  CROSS := mips64-elf-
+else
+  $(error Unable to detect a suitable MIPS toolchain installed.)
+endif
+
+# Prefer cross toolchain C preprocessor or clang if installed on the system
+ifneq (,$(call find-command,$(CROSS)clang))
+  CPP      := $(CROSS)cpp
+  CPPFLAGS := -P
+else ifneq (,$(call find-command,clang))
+  CPP      := clang
+  CPPFLAGS := -E -P -x c
+else
+  CPP      := cpp
+  CPPFLAGS := -P
+endif
+
 AS = $(CROSS)as
 LD = $(CROSS)ld
 OBJDUMP = $(CROSS)objdump
@@ -48,8 +75,6 @@ OBJCOPY = $(CROSS)objcopy
 PYTHON = python3
 SPLAT = $(PYTHON) -m splat split
 N64CRC = $(TOOLS_DIR)/n64crc.py
-CPP := $(CROSS)cpp
-ICONV := iconv --from-code=UTF-8 --to-code=Shift-JIS
 
 COMPILER_DIR = tools/gcc_kmc
 CC := COMPILER_PATH=$(COMPILER_DIR) $(COMPILER_DIR)/gcc
@@ -111,14 +136,14 @@ nonmatching: dirs no_verify
 
 dirs:
 	$(foreach dir,$(ASM_DIRS) $(BIN_DIRS),$(shell mkdir -p $(BUILD_DIR)/$(dir)))
-	@rm -f $(BUILD_LOG)
+	$(V)rm -f $(BUILD_LOG)
 
 verify: $(TARGET).z64
-	@shasum --check $(BASENAME).sha1
+	$(V)shasum --check $(BASENAME).sha1
 
 no_verify: $(TARGET).z64
 	@echo "Skipping SHA1SUM check (DEBUG=$(DEBUG) or NON_MATCHING=$(NON_MATCHING)), updating CRC"
-	@$(PYTHON) $(N64CRC) $(TARGET).z64
+	$(V)$(PYTHON) $(N64CRC) $(TARGET).z64
 
 extract:
 	$(SPLAT) $(BASENAME).yaml
@@ -136,10 +161,10 @@ clean-libmus:
 	rm -r lib/libmus/build
 
 diff-line:
-	@(diff --old-line-format='OLD: %L' --new-line-format='NEW: %L' <(xxd snowboardkids2.z64) <(xxd build/snowboardkids2.z64) || true) > romdiff
+	$(V)(diff --old-line-format='OLD: %L' --new-line-format='NEW: %L' <(xxd snowboardkids2.z64) <(xxd build/snowboardkids2.z64) || true) > romdiff
 
 diff-sxs:
-	@(diff -y <(xxd snowboardkids2.z64) <(xxd build/snowboardkids2.z64) || true) > romdiff
+	$(V)(diff -y <(xxd snowboardkids2.z64) <(xxd build/snowboardkids2.z64) || true) > romdiff
 
 format:
 	clang-format -i -style=file $(C_FILES) $(FORMAT_H_FILES)
@@ -149,7 +174,7 @@ tidy:
 
 $(TARGET).elf: $(BASENAME).ld $(BUILD_DIR)/lib/libgultra_rom.a $(BUILD_DIR)/lib/libmus.a $(O_FILES)
 	$(PRINTF) "[$(PINK) linker $(NO_COL)]  Linking $(TARGET).elf\n"
-	@$(LD) $(LD_FLAGS) $(foreach ld, $(LINKER_SCRIPTS), -T $(ld)) -o $@
+	$(V)$(LD) $(LD_FLAGS) $(foreach ld, $(LINKER_SCRIPTS), -T $(ld)) -o $@
 
 # Per-file optimization overrides
 $(BUILD_DIR)/src/graphics/tiled_sprite_grid.o: OPT_FLAGS := -O0
@@ -159,26 +184,23 @@ CHARMAP = $(TOOLS_DIR)/charmap.txt
 
 $(BUILD_DIR)/src/%.o: src/%.c $(CHARMAP)
 	@mkdir -p $(shell dirname $@)
-	$(PRINTF) "[$(GREEN)   c    $(NO_COL)]  src/$*.c\n"; \
-	$(TEXTCONV) $(CHARMAP) $< - | $(CC_CHECK) $(CC_CHECK_FLAGS) -iquote src/$(dir $*) $(IINC) $(MACROS) -I $(dir $*) -I src/ -I $(BUILD_DIR)/$(dir $*) -o $@ -x c - 2>&1 | tee -a $(BUILD_LOG)
-	@$(TEXTCONV) $(CHARMAP) $< - | $(CC) $(CFLAGS_BASE) $(OPT_FLAGS) -fno-asm -I src/$(dir $*) $(IINC) $(MACROS) -I $(dir $*) -I src/ -I $(BUILD_DIR)/$(dir $*) -x c -c -o $@ -
-	$(OBJDUMP_CMD)
+	$(PRINTF) "[$(GREEN)   c    $(NO_COL)]  src/$*.c\n"
+	$(V)$(TEXTCONV) $(CHARMAP) $< - | $(CC_CHECK) $(CC_CHECK_FLAGS) -iquote src/$(dir $*) $(IINC) $(MACROS) -I $(dir $*) -I src/ -I $(BUILD_DIR)/$(dir $*) -o $@ -x c - 2>&1 | tee -a $(BUILD_LOG)
+	$(V)$(TEXTCONV) $(CHARMAP) $< - | $(CC) $(CFLAGS_BASE) $(OPT_FLAGS) -fno-asm -I src/$(dir $*) $(IINC) $(MACROS) -I $(dir $*) -I src/ -I $(BUILD_DIR)/$(dir $*) -x c -c -o $@ -
 
 $(BUILD_DIR)/%.o: %.s
 	@mkdir -p $(shell dirname $@)
-	$(PRINTF) "[$(GREEN)   as   $(NO_COL)]  $<\n"; \
-	cpp -P -I include -I $(BUILD_DIR)/$(dir $*) $< | \
-		$(ICONV) | \
+	$(PRINTF) "[$(GREEN)   as   $(NO_COL)]  $<\n"
+	$(V)$(CPP) $(CPPFLAGS) -I include -I $(BUILD_DIR)/$(dir $*) $< | \
 		$(AS) $(ASFLAGS) -I $(dir $*) -I $(BUILD_DIR)/$(dir $*) -o $@
-	$(OBJDUMP_CMD)
 
 $(BUILD_DIR)/lib/libgultra_rom.a: $(LIBULTRA)
 	@mkdir -p $$(dirname $@)
-	@cp $< $@
+	$(V)cp $< $@
 
 $(BUILD_DIR)/lib/libmus.a: $(LIBMUS)
 	@mkdir -p $$(dirname $@)
-	@cp $< $@
+	$(V)cp $< $@
 
 LIBULTRA_FLAGS = VERSION=J TARGET=libgultra_rom COMPARE=0 MODERN_LD=1 GBIDEFINE="DF3DEX_GBI_2=1"
 $(LIBULTRA):
@@ -191,22 +213,22 @@ $(LIBMUS):
 
 $(BUILD_DIR)/%.o: %.bin
 	$(PRINTF) "[$(PINK) linker $(NO_COL)]  $<\n"
-	@$(LD) -r -b binary -o $(BUILD_DIR)/$(basename $<).o $<
+	$(V)$(LD) -r -b binary -o $(BUILD_DIR)/$(basename $<).o $<
 
 $(TARGET).bin: $(TARGET).elf
 	$(PRINTF) "[$(CYAN) objcpy $(NO_COL)]  $<\n"
-	@$(OBJCOPY) $(OBJCOPYFLAGS) $< $@
+	$(V)$(OBJCOPY) $(OBJCOPYFLAGS) $< $@
 
 $(TARGET).z64: $(TARGET).bin
-	@cp $< $@
+	$(V)cp $< $@
 
 $(BUILD_DIR)/src/%_annotated.s: src/%.c
 	@mkdir -p $(shell dirname $@)
 	$(PRINTF) "[$(CYAN) annot  $(NO_COL)]  Generating annotated assembly for $<\n"
 	@# Compile with debug info to temporary object file
-	@$(CC) $(CFLAGS) -g -fno-asm $(IINC) $(MACROS) -I $(dir $*) -I src/ -I $(BUILD_DIR)/$(dir $*) -c -o $(BUILD_DIR)/src/$*_temp.o $<
+	$(V)$(CC) $(CFLAGS) -g -fno-asm $(IINC) $(MACROS) -I $(dir $*) -I src/ -I $(BUILD_DIR)/$(dir $*) -c -o $(BUILD_DIR)/src/$*_temp.o $<
 	@# Generate disassembly with line numbers
-	@$(OBJDUMP) -d --line-numbers --reloc --source $(BUILD_DIR)/src/$*_temp.o > $@
+	$(V)$(OBJDUMP) -d --line-numbers --reloc --source $(BUILD_DIR)/src/$*_temp.o > $@
 	@# Clean up temp file
 	@rm -f $(BUILD_DIR)/src/$*_temp.o
 	@echo "    Generated: $@"

--- a/README.md
+++ b/README.md
@@ -16,34 +16,43 @@ A matching decompilation of the greatest N64 game ever made, [Snowboard Kids 2](
 Clone this repository, including its submodules:
 
 ```
-git clone --recurse-submodules -j8 git@github.com:cdlewis/snowboardkids2-decomp.git
+git clone --recurse-submodules -j8 https://github.com/cdlewis/snowboardkids2-decomp.git
 ```
 
 # Dependencies
 
-This project has been tested on Ubuntu (x86). Your milege may vary on other systems.
+This project has been tested on Debian/Ubuntu (x86) and macOS. Your mileage may vary on other systems.
 
 System packages:
 
 * make
 * git
-* docker
 * python3
 * pip3
 * binutils-mips-linux-gnu
 
-Build tools:
+On Debian/Ubuntu:
+```sh
+sudo apt install make git python3 pip3 binutils-mips-linux-gnu
+```
+
+On macOS using homebrew. Note that calls below to `make` should use `gmake` instead to run the homebrew version.
+```sh
+brew install make tehzz/n64-dev/mips64-elf-binutils
+```
+
+Install toolchain:
 
 ```bash
 make setup
 ```
 
-Build Python dependencies:
+Install Python dependencies in virtual environment:
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install -U -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ## Building
@@ -66,6 +75,7 @@ Articles
 ========
 
 If you're interested in learning more about decompilation and Snowboard Kids 2, the following articles might be of interest:
+* [Snowboard Kids 2 is 100% Decompiled](http://blog.chrislewis.au/snowboard-kids-2-is-100-decompiled/)
 * [The Long Tail of LLM-Assisted Decompilation](https://blog.chrislewis.au/the-long-tail-of-llm-assisted-decompilation/)
 * [Finding Jingle Town: Debugging an N64 Game without Symbols](https://blog.chrislewis.au/finding-jingle-town-debugging-an-n64-game-without-symbols/)
 * [The Unexpected Effectiveness of One-Shot Decompilation with Claude](https://blog.chrislewis.au/the-unexpected-effectiveness-of-one-shot-decompilation-with-claude/)
@@ -78,7 +88,7 @@ Contributions are most welcome! There are a variety of other ways you can assist
 * Fix compiler warnings
 * Clean up code: you'll see plenty of hastily decopmiled functions that use pointer arithmatic rather than propre struct access. We need help cleaning up these functions.
 * Document code: some functions/variables have useful names (rather than func_XXX or D_XXX) but most don't. Some that do are incorrectly named. We need lots of help investigating and documenting what all these functions do.
-* Get project builds working on Windows and Mac. Currently the build is only verified as working on Linux which limits who can contribute.
+* Support building the project on more platforms such as Windows or ARM Linux. Currently the build is only verified as working on Linux (x86) and macOS which limits who can contribute.
 
 If you have any additional questions, please reach out on Discord (linked in the header). However please note that, since this is a clean room decompilation, we cannot accept contributions based on leaked source code or from those with proprietary knowledge about the game or related subjects.
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -2,10 +2,20 @@ KMC_DIR         := gcc_kmc
 KMC_GCC         := $(KMC_DIR)/gcc
 KMC_BINUTILS    := $(KMC_DIR)/as
 
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Linux)
+  PLATFORM := linux
+else ifeq ($(UNAME_S),Darwin)
+  PLATFORM := mac
+else
+  $(error Unsupported platform for KMC toolchain.)
+endif
+
 all: $(KMC_GCC) $(KMC_BINUTILS)
 
 clean:
-	$(RM) -rf $(KMC_DIR) gcc_kmc
+	$(RM) -rf $(KMC_DIR)
 
 distclean: clean
 
@@ -16,12 +26,12 @@ $(KMC_DIR):
 
 $(KMC_GCC): | $(KMC_DIR)
 	@mkdir -p $(KMC_DIR)
-	wget https://github.com/decompals/mips-gcc-2.7.2/releases/latest/download/gcc-2.7.2-linux.tar.gz
-	tar xf gcc-2.7.2-linux.tar.gz -C $(KMC_DIR)
-	rm gcc-2.7.2-linux.tar.gz
+	curl -O -L https://github.com/decompals/mips-gcc-2.7.2/releases/latest/download/gcc-2.7.2-$(PLATFORM).tar.gz
+	tar xf gcc-2.7.2-$(PLATFORM).tar.gz -C $(KMC_DIR)
+	rm gcc-2.7.2-$(PLATFORM).tar.gz
 
 $(KMC_BINUTILS): | $(KMC_DIR)
 	@mkdir -p $(KMC_DIR)
-	wget https://github.com/decompals/mips-binutils-2.6/releases/latest/download/binutils-2.6-linux.tar.gz
-	tar xf binutils-2.6-linux.tar.gz -C $(KMC_DIR)
-	rm binutils-2.6-linux.tar.gz
+	curl -O -L https://github.com/decompals/mips-binutils-2.6/releases/latest/download/binutils-2.6-$(PLATFORM).tar.gz
+	tar xf binutils-2.6-$(PLATFORM).tar.gz -C $(KMC_DIR)
+	rm binutils-2.6-$(PLATFORM).tar.gz


### PR DESCRIPTION
- Detect cross toolchain to support mips-linux-gnu, mips64-linux-gnu, and mips64-elf
- Prefer cross cpp or clang for preprocessing (macOS cpp is clang)
- Download using curl instead of wget as curl is more widely available
- Remove call to ICONV for assembly pre-processing
- Remove unused OBJDUMP_CMD
- Update README